### PR TITLE
Change framework target version to .net v4.0

### DIFF
--- a/X-Mouse Controls/X-Mouse Controls.csproj
+++ b/X-Mouse Controls/X-Mouse Controls.csproj
@@ -14,7 +14,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>XMouseControls</RootNamespace>
     <AssemblyName>X-Mouse Controls</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -42,6 +42,7 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -71,6 +72,7 @@
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />


### PR DESCRIPTION
- Makes for easier execution on Windows systems without .net v3.5, but has .net v4+. No need for a separate `app.config` there, as it is today.
- Crashes on Windows systems with only .net v3.5.
- Targets application to (primarily) Windows 10, while leaving (primarily) Windows 7 behind.
  - Both are still popular, with a high number of users and large market shares.
  - September 2018:
    - Windows 10: 50.07%
    - Windows 7: 37.2%
- Can both systems be targeted at once, similar to #11/#12 but without `app.config`?

See

- https://github.com/joelpurra/xmouse-controls/issues/11
- https://github.com/joelpurra/xmouse-controls/pull/12
- https://en.wikipedia.org/wiki/Windows_10#Market_share_and_sales